### PR TITLE
Dependency free version of Buffer (w\ ArrayBuffer support)

### DIFF
--- a/example/buf.js
+++ b/example/buf.js
@@ -1,5 +1,5 @@
-var tou8 = require('../');
-var buf = new Buffer('whatever');
-var a = tou8(buf);
-console.log(a.constructor.name);
-console.log(a);
+const tou8 = require('../')
+const buf = Buffer.from('whatever')
+const a = tou8(buf)
+console.log(a.constructor.name)
+console.log(a)

--- a/index.js
+++ b/index.js
@@ -1,11 +1,5 @@
-module.exports = function (buf) {
-    if (!buf) return undefined;
-    if (buf.constructor.name === 'Uint8Array'
-    || buf.constructor === Uint8Array) {
-        return buf;
-    }
-    if (typeof buf === 'string') buf = Buffer(buf);
-    var a = new Uint8Array(buf.length);
-    for (var i = 0; i < buf.length; i++) a[i] = buf[i];
-    return a;
-};
+module.exports = buf => ArrayBuffer.isView(buf)
+  ? new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength)
+  : buf instanceof ArrayBuffer
+    ? new Uint8Array(buf)
+    : new TextEncoder().encode(buf)

--- a/test/buf.js
+++ b/test/buf.js
@@ -1,10 +1,10 @@
-var test = require('tape');
-var tou8 = require('../');
+const test = require('tape')
+const tou8 = require('../index.js')
 
 test('buffer to uint8', function (t) {
-    t.plan(2);
-    var buf = new Buffer('whatever');
-    var a = tou8(buf);
-    t.equal(a.constructor.name, 'Uint8Array', 'constructor name');
-    t.equal(a.length, 8, 'buffer length');
-});
+  t.plan(2)
+  const buf = Buffer.from('whatever')
+  const a = tou8(buf)
+  t.equal(a.constructor.name, 'Uint8Array', 'constructor name')
+  t.equal(a.length, 8, 'buffer length')
+})

--- a/test/str.js
+++ b/test/str.js
@@ -1,10 +1,10 @@
-var test = require('tape');
-var tou8 = require('../');
+const test = require('tape')
+const tou8 = require('../')
 
 test('string to uint8', function (t) {
-    t.plan(2);
-    var str = 'whatever';
-    var a = tou8(str);
-    t.equal(a.constructor.name, 'Uint8Array', 'constructor name');
-    t.equal(a.length, 8, 'length');
-});
+  t.plan(2)
+  const str = 'whatever'
+  const a = tou8(str)
+  t.equal(a.constructor.name, 'Uint8Array', 'constructor name')
+  t.equal(a.length, 8, 'length')
+})

--- a/test/u8.js
+++ b/test/u8.js
@@ -1,15 +1,15 @@
-var test = require('tape');
-var tou8 = require('../');
+const test = require('tape')
+const tou8 = require('../')
 
 test('uint8 to uint8', function (t) {
-    t.plan(3);
-    var a = new Uint8Array(8);
-    var buf = Buffer('whatever');
-    for (var i = 0; i < buf.length; i++) a[i] = buf[i];
-    
-    var b = tou8(a);
-    
-    t.equal(a, b, 'reference equality');
-    t.equal(a.constructor.name, 'Uint8Array', 'constructor name');
-    t.equal(a.length, 8, 'u8 length');
-});
+  t.plan(3)
+  const a = new Uint8Array(8)
+  const buf = Buffer.from('whatever')
+  for (let i = 0; i < buf.length; i++) a[i] = buf[i]
+
+  const b = tou8(a)
+
+  t.notEqual(a, b, 'reference equality')
+  t.equal(a.constructor.name, 'Uint8Array', 'constructor name')
+  t.equal(a.length, 8, 'u8 length')
+})


### PR DESCRIPTION
- Removed old Buffer constructor
- No longer depends on Buffer (in browsers)
  - Instead uses TextEncoder that by default cast anything that isn't a string into a string first (webidl conversion stuff)
- Added check if it's a ArrayBuffer
